### PR TITLE
replace the local snapshot root with a named path

### DIFF
--- a/snapshot/localmounter_unix.go
+++ b/snapshot/localmounter_unix.go
@@ -11,6 +11,14 @@ import (
 	"github.com/pkg/errors"
 )
 
+const localSnapshotRoot = "/var/lib/buildkit/local-snapshot"
+
+func init() {
+	if err := os.MkdirAll(localSnapshotRoot, 0640); err != nil {
+		panic(err)
+	}
+}
+
 func (lm *localMounter) Mount() (string, error) {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
@@ -37,7 +45,7 @@ func (lm *localMounter) Mount() (string, error) {
 		}
 	}
 
-	dir, err := ioutil.TempDir("", "buildkit-mount")
+	dir, err := ioutil.TempDir(localSnapshotRoot, "buildkit-mount")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create temp dir")
 	}


### PR DESCRIPTION
This PR moved the local snapshot root to `/var/lib/buildkit/local-snapshot` from ~~/tmp~~, that, we can share local snapshots with host processes after mounted to a hostpath. In this case, the host process would be **containerd**.