### PR TITLE
configurable local snapshot root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ images: FORCE
 	hack/images local moby/buildkit
 	TARGET=rootless hack/images local moby/buildkit
 
+dev-images: FORCE
+# moby/buildkit:local and moby/buildkit:local-rootless are created on Docker
+	hack/images-dev local docker.io/warmmetal/buildkit
+	TARGET=rootless hack/images-dev local docker.io/warmmetal/buildkit
+
 install: FORCE
 	mkdir -p $(DESTDIR)$(bindir)
 	install bin/* $(DESTDIR)$(bindir)
@@ -42,5 +47,5 @@ vendor:
 generated-files:
 	./hack/update-generated-files
 
-.PHONY: vendor generated-files test binaries images install clean lint validate-all validate-vendor validate-generated-files
+.PHONY: vendor generated-files test binaries images dev-images install clean lint validate-all validate-vendor validate-generated-files
 FORCE:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Changes
-1. Local snapshots are mount to a named path instead of `/tmp`. [PR#1](https://github.com/warm-metal/buildkit/pull/1)
+1. Local snapshots are mount to a named path instead of `/tmp`. [PR#1](https://github.com/warm-metal/buildkit/pull/1), [PR#3](https://github.com/warm-metal/buildkit/pull/3)
 2. **http_proxy**s of buildkitd will be used to build images. [PR#2](https://github.com/warm-metal/buildkit/pull/2)
+3. Build buildkit images in buildkitd itself. Try `make dev-images` if you have `kubectl-dev` installed. [PR#3](https://github.com/warm-metal/buildkit/pull/3)
 
 The privileged image is open in [DockerHub](https://hub.docker.com/r/warmmetal/buildkit). Fell free to test.
 

--- a/cmd/buildkitd/config/config.go
+++ b/cmd/buildkitd/config/config.go
@@ -9,6 +9,8 @@ type Config struct {
 	// Root is the path to a directory where buildkit will store persistent data
 	Root string `toml:"root"`
 
+	SnapshotRoot string `toml:"snapshot-root"`
+
 	//Entitlements e.g. security.insecure, network.host
 	Entitlements []string `toml:"insecure-entitlements"`
 	// GRPC configuration settings

--- a/cmd/buildkitd/main.go
+++ b/cmd/buildkitd/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"github.com/moby/buildkit/snapshot"
 	"io/ioutil"
 	"net"
 	"os"
@@ -201,6 +202,8 @@ func main() {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
 
+		snapshot.InitRoot(cfg.SnapshotRoot)
+
 		if cfg.GRPC.DebugAddress != "" {
 			if err := setupDebugHandlers(cfg.GRPC.DebugAddress); err != nil {
 				return err
@@ -376,6 +379,10 @@ func setDefaultConfig(cfg *config.Config) {
 
 	if cfg.Root == "" {
 		cfg.Root = appdefaults.Root
+	}
+
+	if cfg.SnapshotRoot == "" {
+		cfg.SnapshotRoot = appdefaults.SnapshotRoot
 	}
 
 	if len(cfg.GRPC.Address) == 0 {

--- a/hack/images-dev
+++ b/hack/images-dev
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+TAG=$1
+REPO=$2
+PUSH=$3
+
+. $(dirname $0)/util
+set -eu -o pipefail
+
+: ${PLATFORMS=linux/amd64}
+: ${TARGET=}
+
+versionTag=$(git describe --always --tags --match "v[0-9]*")
+
+if [[ ! "$versionTag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  versionTag=""
+fi
+
+usage() {
+  echo "usage: $0 <tag> <repo> [push]"
+  exit 1
+}
+
+if [ -z "$TAG" ] || [ -z "$REPO" ]; then
+  usage
+fi
+
+localmode=""
+if [[ "$TAG" == "local" ]]; then
+  localmode="1"
+  if [ "$PUSH" = "push" ]; then
+    echo >&2 "local images cannot be pushed"
+    exit 1
+  fi
+fi
+
+outputFlag="--output=type=image,push=false"
+if [ "$PUSH" = "push" ]; then
+  outputFlag="--output=type=image,push=true"
+fi
+if [ -n "$localmode" ]; then
+  outputFlag="--output=type=docker"
+fi
+
+targetFlag=""
+if [ -n "$TARGET" ]; then
+  targetFlag="--target=$TARGET"
+fi
+
+tagNames="$REPO:$TAG"
+if [ -n "$TARGET" ]; then
+  tagNames="$tagNames-$TARGET"
+fi
+
+if [[ "$versionTag" == "$TAG" ]]; then
+  if [ -n "$TARGET" ]; then
+    tagNames="$tagNames $REPO:$TARGET"
+  else
+    tagNames="$tagNames $REPO:latest"
+  fi
+fi
+
+importCacheFlags=""
+for tagName in $tagNames; do
+  importCacheFlags="$importCacheFlags--cache-from=type=registry,ref=$tagName "
+done
+if [[ -n "$cacheRefFrom" ]] && [[ "$cacheType" = "local" ]]; then
+  for ref in $cacheRefFrom; do
+    importCacheFlags="$importCacheFlags--cache-from=type=local,src=$ref "
+  done
+fi
+if [ -n "$localmode" ]; then
+  importCacheFlags=""
+fi
+
+exportCacheFlags=""
+if [[ -n "$cacheRefTo" ]] && [[ "$cacheType" = "local" ]]; then
+  exportCacheFlags="--cache-to=type=local,dest=$cacheRefTo "
+elif [ "$PUSH" = "push" ]; then
+  exportCacheFlags="$exportCacheFlags--cache-to=type=inline "
+fi
+
+tagFlags=""
+for tagName in $tagNames; do
+  tagFlags="$tagFlags--tag=$tagName "
+done
+
+kubectl dev build $targetFlag $tagFlags $currentcontext

--- a/snapshot/localmounter_unix.go
+++ b/snapshot/localmounter_unix.go
@@ -11,9 +11,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-const localSnapshotRoot = "/var/lib/buildkit/local-snapshot"
+var localSnapshotRoot = ""
 
-func init() {
+func InitRoot(snapshotRoot string) {
+	localSnapshotRoot = snapshotRoot
 	if err := os.MkdirAll(localSnapshotRoot, 0640); err != nil {
 		panic(err)
 	}

--- a/util/appdefaults/appdefaults_unix.go
+++ b/util/appdefaults/appdefaults_unix.go
@@ -9,9 +9,10 @@ import (
 )
 
 const (
-	Address   = "unix:///run/buildkit/buildkitd.sock"
-	Root      = "/var/lib/buildkit"
-	ConfigDir = "/etc/buildkit"
+	Address      = "unix:///run/buildkit/buildkitd.sock"
+	Root         = "/var/lib/buildkit"
+	SnapshotRoot = "/var/lib/buildkit/local-snapshot"
+	ConfigDir    = "/etc/buildkit"
 )
 
 // UserAddress typically returns /run/user/$UID/buildkit/buildkitd.sock


### PR DESCRIPTION
1. Set `snapshot-root` in the `buildkitd.toml` file.
2. A new choice to build images via `kubectl-dev`.